### PR TITLE
test whitespace-prefixed markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ bar.
 
 ---
 
+ ## This is a `##` header(?) prefixed with a space, let's see if it counts as header?
+
 ## LaTeX sync playground
 
 As of 2015–2016 my recommendadion for collaborative LaTeX editing is [Overleaf](https://overleaf.com) (former WriteLaTeX).


### PR DESCRIPTION
https://stackoverflow.com/a/2788126/239657 claims prepending a single space prevents git from stripping `#`.  This PR (created from command line via `hub`) tests that.

 ## this line starts with space-prefixed ` ##`

next line started with `###` when I typed this into editor
EDIT: predictably it didn't make it.

\## This line starts with backslash-escaped `\##`